### PR TITLE
Replace HttpClient with WebClient

### DIFF
--- a/Neon.Downloader.Console/Program.cs
+++ b/Neon.Downloader.Console/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 
 namespace Neon.Downloader.Console
 {
@@ -24,7 +25,7 @@ namespace Neon.Downloader.Console
 
         private async static void Start(string url)
         {
-            await _downloader.DownloadToFileAsync(url,"homeboyz.mp3", @"F:\downloads");
+            await _downloader.DownloadToFileAsync(url, @"F:\downloads", "homeboyz.mp3", CancellationToken.None);
             string x = null;
         }
         private static void _downloader_OnError(Exception ex)

--- a/Neon.Downloader/DownloadClient.cs
+++ b/Neon.Downloader/DownloadClient.cs
@@ -1,7 +1,10 @@
 ﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -14,6 +17,7 @@ namespace Neon.Downloader
 {
     public class DownloaderClient : IDownloader
     {
+        private const long MaxSize = 1000000 * 1000;
         private readonly HttpClient _client;
         private readonly long _maxDowloadSize;
         private readonly CancellationToken nullToken = CancellationToken.None;
@@ -22,7 +26,7 @@ namespace Neon.Downloader
         /// </summary>
         public DownloaderClient()
         {
-            _maxDowloadSize = 1000000 * 1000;
+            _maxDowloadSize = MaxSize;
             //Ignore bad certificate in .NET core 2.0
             var httpClientHandler = new HttpClientHandler
             {
@@ -34,7 +38,7 @@ namespace Neon.Downloader
         /// Instanciates download client with a max download size;
         /// </summary>
         /// <param name="maxDownloadSizeInBytes">Maximum download limit in bytes. Default is 500 MB.</param>
-        public DownloaderClient(long maxDownloadSizeInBytes=1000000*500) :this()
+        public DownloaderClient(long maxDownloadSizeInBytes=MaxSize) :this()
         {
             _maxDowloadSize = maxDownloadSizeInBytes;
         }
@@ -88,12 +92,13 @@ namespace Neon.Downloader
         }
         public Task DownloadToFileAsync(string url, string folderPath)
         {
-            return DownloadToFileAsync(url, null, folderPath);
+            return InternalDownloadAsync(new Uri(url), nullToken, true, null, folderPath);
         }
-        public async Task DownloadToFileAsync(string url, string filename, string folderPath)
+        public Task<byte[]> DownloadToFileAsync(string url, string folder, string filename, CancellationToken ct)
         {
-            await InternalDownloadAsync(new Uri(url), nullToken, true, filename, folderPath);
+            return InternalDownloadAsync2(new Uri(url), folder, filename, ct);
         }
+        public Task<byte[]> DownloadToFileAsync(string url, Stream output, CancellationToken ct) => InternalDownloadAsync2(new Uri(url), output,ct);
         public void DownloadToFile(Uri uri)
         {
             DownloadToFile(uri, null);
@@ -178,7 +183,141 @@ namespace Neon.Downloader
             }
             return vs;
         }
+        public Task<byte[]> InternalDownloadAsync2(Uri uri, string folder, string filename, CancellationToken ct)
+        {
+            return InternalDownloadAsync2(uri, File.Open(Path.Combine(folder, filename), FileMode.OpenOrCreate, FileAccess.Write), ct);
+        }
+        public async Task<byte[]> InternalDownloadAsync2(Uri uri, Stream output, CancellationToken ct)
+        {
+            byte[] vs = Array.Empty<byte>();
+            try
+            {
+                ServicePointManager.ServerCertificateValidationCallback = delegate { return true; };
+                #region Get file size  
+                WebRequest webRequest = WebRequest.Create(uri);
+                webRequest.Method = "HEAD";
+                long? bytes;
+                Stopwatch watch = new Stopwatch();
+                watch.Start();
+                DownloadMetric m = new DownloadMetric();
+                using (WebResponse webResponse = webRequest.GetResponse())
+                {
+                    bytes = long.Parse(webResponse.Headers.Get("Content-Length"));
+                    m.TotalBytes = bytes.Value;
+                    m.ElapsedTime = watch.Elapsed;
+                    OnDownloadStart?.Invoke(m);
+                }
+                /*__________________________________________________________________________________
+                  |                                                                                |
+                  |  .NET runtime has a 2GB size limit for objects.                                |
+                  |  ----------------------------------------------                                |
+                  |  To adhere to this restriction, this module ONLY allows downloading files      |
+                  |  less than 1GB. If the file is greater than 1GB, call DownloadToFile method    |
+                  |  instead which downloads the file directly to disk or allow this application   |
+                  |  to automatically save the file to disk for you.                               |
+                  |  ----------------------------------------------                                |
+                  |  1 GB = 1,000,000,000 (1 Billion Bytes).                                       |
+                  |                                                                                |
+                 *|________________________________________________________________________________|*/
+                if (bytes == null)
+                    bytes = _maxDowloadSize;
+                else
+                {
+                    if (bytes.Value > _maxDowloadSize)
+                        bytes = _maxDowloadSize;
+                }
+                #endregion
 
+                long? l = bytes;
+                HttpWebRequest req = WebRequest.Create(uri) as HttpWebRequest;
+                req.Method = "GET";
+                req.AddRange(0, bytes.Value);
+                vs = await Task.Run(async () =>
+                {
+                    using (StreamReader sr = new StreamReader((await req.GetResponseAsync()).GetResponseStream()))
+                    {
+                        var a = FromReaderToStream(sr, output, ref m, ref watch, ref l, ct);
+                        DownloadCompleted?.Invoke(m, null);
+                        return a;
+                    }
+                }, ct);
+            }
+            catch (OperationCanceledException)
+            {
+                OnError?.Invoke(new DownloadClientException($"Download cancelled by user."));
+            }
+            catch (Exception ex)
+            {
+                OnError?.Invoke(new DownloadClientException("Download failed. See inner exception for details ", ex));
+            }
+            return vs;
+        }
+
+        public Task<DownloadResult> ProcessParallel(Uri uri, long bytes, int threads, string destinationFilePath, DownloadResult result)
+        {
+            return Task.Run(() =>
+            {
+                Stopwatch watch = new Stopwatch();
+                watch.Start();
+                DownloadMetric m = new DownloadMetric();
+                using (FileStream destinationStream = new FileStream(destinationFilePath, FileMode.Append))
+                {
+                    ConcurrentDictionary<int, string> temps = new ConcurrentDictionary<int, string>();
+
+                    #region Calculate ranges  
+                    List<Range> ranges = new List<Range>();
+                    for (int i = 0; i < threads - 1; i++)
+                    {
+                        var range = new Range()
+                        {
+                            Start = i * (bytes / threads),
+                            End = ((i + 1) * (bytes / threads)) - 1
+                        };
+                        ranges.Add(range);
+                    }
+                    ranges.Add(new Range()
+                    {
+                        Start = ranges.Any() ? ranges.Last().End + 1 : 0,
+                        End = bytes - 1
+                    });
+                    #endregion
+
+                    #region Parallel download  
+                    int index = 0;
+                    Parallel.ForEach(ranges, new ParallelOptions() { MaxDegreeOfParallelism = threads }, (range) =>
+                    {
+                        long? range_length = range.End - range.Start;
+                        HttpWebRequest httpWebRequest = WebRequest.Create(uri) as HttpWebRequest;
+                        httpWebRequest.Method = "GET";
+                        httpWebRequest.AddRange(range.Start, range.End);
+                        using (StreamReader sr = new StreamReader(httpWebRequest.GetResponse().GetResponseStream()))
+                        {
+                            string tempFilePath = Path.GetTempFileName();
+                            using (var fileStream = new FileStream(tempFilePath, FileMode.Create, FileAccess.Write, FileShare.Write))
+                            {
+                                FromReaderToStream(sr, fileStream,
+                                        ref m, ref watch, ref range_length, CancellationToken.None);
+                                temps.TryAdd(index, tempFilePath);
+                            }
+                        }
+                    });
+                    result.ParallelDownloads = index;
+                    #endregion
+
+                    result.TimeTaken = watch.Elapsed;
+
+                    #region Merge to single file  
+                    foreach (var tempFile in temps.OrderBy(b => b.Key))
+                    {
+                        byte[] tempFileBytes = File.ReadAllBytes(tempFile.Value);
+                        destinationStream.Write(tempFileBytes, 0, tempFileBytes.Length);
+                        File.Delete(tempFile.Value);
+                    }
+                    #endregion
+                    return result;
+                }
+            });
+        }
         internal async Task<byte[]> ReadHttpResponseStreamAsync(HttpResponseMessage httpResponse, long? length, CancellationToken ct, bool saveToFile=false, string filename=null, string folderPath=null)
         {
             return await Task.Run(async () =>
@@ -207,7 +346,8 @@ namespace Neon.Downloader
         internal byte[] FromReaderToStream(StreamReader sr, Stream destinationStream,
             ref DownloadMetric metric, ref Stopwatch stopwatch, ref long? length, CancellationToken ct)
         {
-            int kb = metric.Speed > Globals.PageSize ? (int)metric.Speed : Globals.PageSize;
+            //int kb = metric.Speed > Globals.PageSize ? (int)metric.Speed : Globals.PageSize;
+            int kb = 1024*20;
             int toDownload = kb;
             var buffer = new byte[toDownload];
             int bytesRead;
@@ -239,8 +379,8 @@ namespace Neon.Downloader
                 buffer = new byte[toDownload];
             }
             stopwatch.Stop();
-            DownloadCompleted?.Invoke(metric, destinationStream);
-            stopwatch.Reset();
+            //DownloadCompleted?.Invoke(metric, destinationStream);
+            //stopwatch.Reset();
             
             if(destinationStream is MemoryStream) {
                 return ((MemoryStream)destinationStream).ToArray();
@@ -252,7 +392,6 @@ namespace Neon.Downloader
                 return null;
             }
         }
-
         internal string ToRelativeFilePath(Uri uri, string filename = null, string folderPath = null)
         {
             string path;
@@ -307,10 +446,29 @@ namespace Neon.Downloader
 
             return path;
         }
-
         public string GetFileNameFrom(string url) => GetFileNameFrom(new Uri(url));
         public string GetFileNameFrom(Uri uri) => Helpers.Extensions.GetFileNameFrom(uri);
         public FileType GetFileTypeFrom(string url) => GetFileTypeFrom(new Uri(url));
         public FileType GetFileTypeFrom(Uri uri) => Helpers.Extensions.GetFileTypeFrom(uri);
+    }
+    public class DownloadResult
+    {
+        public long Size { get; set; }
+        public String FilePath { get; set; }
+        public TimeSpan TimeTaken { get; set; }
+        public int ParallelDownloads { get; set; }
+    }
+    internal class Range
+    {
+        public Range()
+        { }
+        public Range(long start, long end) :this()
+        {
+            Start = start;
+            End = end;
+        }
+        public long Start { get; set; }
+        public long End { get; set; }
+        public long Length => End - Start;
     }
 }

--- a/Neon.Downloader/DownloadClient.cs
+++ b/Neon.Downloader/DownloadClient.cs
@@ -10,6 +10,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Common;
+using Common.Primitives;
 using Neon.Downloader.Enums;
 using Neon.Downloader.Exceptions;
 
@@ -20,7 +21,7 @@ namespace Neon.Downloader
         private const long MaxSize = 1000000 * 1000;
         private readonly HttpClient _client;
         private readonly long _maxDowloadSize;
-        private readonly CancellationToken nullToken = CancellationToken.None;
+        private CancellationToken nullToken => CancellationToken.None;
         /// <summary>
         /// Instanciates download client with a max download size of 1GB.
         /// </summary>
@@ -47,6 +48,7 @@ namespace Neon.Downloader
         public event DownloadEventHandler OnDownloadStart;
         public event DownloadErrorEventHandler OnError;
         public event DownloadCompletedEventHandler DownloadCompleted;
+        public event DownloadTraceEventHandler DownloadTrace;
 
         public byte[] Download(Uri uri)
         {
@@ -96,9 +98,9 @@ namespace Neon.Downloader
         }
         public Task<byte[]> DownloadToFileAsync(string url, string folder, string filename, CancellationToken ct)
         {
-            return InternalDownloadAsync2(new Uri(url), folder, filename, ct);
+            return ProcessDownloadAsync(new Uri(url), folder, filename, ct);
         }
-        public Task<byte[]> DownloadToFileAsync(string url, Stream output, CancellationToken ct) => InternalDownloadAsync2(new Uri(url), output,ct);
+        public Task<byte[]> DownloadToFileAsync(string url, Stream output, CancellationToken ct) => ProcessDownloadAsync(new Uri(url), output,ct);
         public void DownloadToFile(Uri uri)
         {
             DownloadToFile(uri, null);
@@ -128,7 +130,7 @@ namespace Neon.Downloader
             await InternalDownloadAsync(uri, cancellationToken, true, filename, folderPath);
         }
 
-
+        [Obsolete("Issues encountered working with this method. Please migrate to using 'ProcessDownloadAsync' method which is much efficient & resilient to runtime errors/issues.",false)]
         internal async Task<byte[]> InternalDownloadAsync(Uri uri, CancellationToken cancellationToken, bool saveToDisk=false, string filename=null, string folderPath=null)
         {
             byte[] vs = Array.Empty<byte>();
@@ -183,29 +185,31 @@ namespace Neon.Downloader
             }
             return vs;
         }
-        public Task<byte[]> InternalDownloadAsync2(Uri uri, string folder, string filename, CancellationToken ct)
+        internal Task<byte[]> ProcessDownloadAsync(Uri uri, string folder, string filename, CancellationToken ct)
         {
-            return InternalDownloadAsync2(uri, File.Open(Path.Combine(folder, filename), FileMode.OpenOrCreate, FileAccess.Write), ct);
+            return ProcessDownloadAsync(uri, File.Open(Path.Combine(folder, filename), FileMode.OpenOrCreate, FileAccess.Write), ct);
         }
-        public async Task<byte[]> InternalDownloadAsync2(Uri uri, Stream output, CancellationToken ct)
+        internal async Task<byte[]> ProcessDownloadAsync(Uri uri, Stream output, CancellationToken ct)
         {
             byte[] vs = Array.Empty<byte>();
             try
             {
-                ServicePointManager.ServerCertificateValidationCallback = delegate { return true; };
+
                 #region Get file size  
+                DownloadTrace?.Invoke("Getting file size...");
                 WebRequest webRequest = WebRequest.Create(uri);
                 webRequest.Method = "HEAD";
-                long? bytes;
                 Stopwatch watch = new Stopwatch();
-                watch.Start();
                 DownloadMetric m = new DownloadMetric();
+                long? bytes;
+                watch.Start();
                 using (WebResponse webResponse = webRequest.GetResponse())
                 {
                     bytes = long.Parse(webResponse.Headers.Get("Content-Length"));
+                    DownloadTrace?.Invoke($"File size: {bytes.Value.HumanizeBytes(2)}");
                     m.TotalBytes = bytes.Value;
                     m.ElapsedTime = watch.Elapsed;
-                    OnDownloadStart?.Invoke(m);
+                    
                 }
                 /*__________________________________________________________________________________
                   |                                                                                |
@@ -228,96 +232,44 @@ namespace Neon.Downloader
                 }
                 #endregion
 
+                #region Read Content Stream Asynchronously
                 long? l = bytes;
+                DownloadTrace?.Invoke("Download about to begin.");
+                DownloadTrace.Invoke("On your marks...");
                 HttpWebRequest req = WebRequest.Create(uri) as HttpWebRequest;
                 req.Method = "GET";
                 req.AddRange(0, bytes.Value);
                 vs = await Task.Run(async () =>
                 {
+                    // Check if operation is already canceled?
+                    ct.ThrowIfCancellationRequested();
+                    
                     using (StreamReader sr = new StreamReader((await req.GetResponseAsync()).GetResponseStream()))
                     {
+                        DownloadTrace.Invoke("Download started!");
+                        OnDownloadStart?.Invoke(m);
                         var a = FromReaderToStream(sr, output, ref m, ref watch, ref l, ct);
                         DownloadCompleted?.Invoke(m, null);
                         return a;
                     }
                 }, ct);
+                #endregion
             }
             catch (OperationCanceledException)
             {
-                OnError?.Invoke(new DownloadClientException($"Download cancelled by user."));
+                string msg = "Download cancelled by user";
+                DownloadTrace.Invoke(msg);
+                OnError?.Invoke(new DownloadClientException(msg));
             }
             catch (Exception ex)
             {
-                OnError?.Invoke(new DownloadClientException("Download failed. See inner exception for details ", ex));
+                string msg = "An unexpected error occured.";
+                DownloadTrace?.Invoke(msg);
+                OnError?.Invoke(new DownloadClientException($"{msg}\n\nDownload failed. See inner exception for details.", ex));
             }
             return vs;
         }
 
-        public Task<DownloadResult> ProcessParallel(Uri uri, long bytes, int threads, string destinationFilePath, DownloadResult result)
-        {
-            return Task.Run(() =>
-            {
-                Stopwatch watch = new Stopwatch();
-                watch.Start();
-                DownloadMetric m = new DownloadMetric();
-                using (FileStream destinationStream = new FileStream(destinationFilePath, FileMode.Append))
-                {
-                    ConcurrentDictionary<int, string> temps = new ConcurrentDictionary<int, string>();
-
-                    #region Calculate ranges  
-                    List<Range> ranges = new List<Range>();
-                    for (int i = 0; i < threads - 1; i++)
-                    {
-                        var range = new Range()
-                        {
-                            Start = i * (bytes / threads),
-                            End = ((i + 1) * (bytes / threads)) - 1
-                        };
-                        ranges.Add(range);
-                    }
-                    ranges.Add(new Range()
-                    {
-                        Start = ranges.Any() ? ranges.Last().End + 1 : 0,
-                        End = bytes - 1
-                    });
-                    #endregion
-
-                    #region Parallel download  
-                    int index = 0;
-                    Parallel.ForEach(ranges, new ParallelOptions() { MaxDegreeOfParallelism = threads }, (range) =>
-                    {
-                        long? range_length = range.End - range.Start;
-                        HttpWebRequest httpWebRequest = WebRequest.Create(uri) as HttpWebRequest;
-                        httpWebRequest.Method = "GET";
-                        httpWebRequest.AddRange(range.Start, range.End);
-                        using (StreamReader sr = new StreamReader(httpWebRequest.GetResponse().GetResponseStream()))
-                        {
-                            string tempFilePath = Path.GetTempFileName();
-                            using (var fileStream = new FileStream(tempFilePath, FileMode.Create, FileAccess.Write, FileShare.Write))
-                            {
-                                FromReaderToStream(sr, fileStream,
-                                        ref m, ref watch, ref range_length, CancellationToken.None);
-                                temps.TryAdd(index, tempFilePath);
-                            }
-                        }
-                    });
-                    result.ParallelDownloads = index;
-                    #endregion
-
-                    result.TimeTaken = watch.Elapsed;
-
-                    #region Merge to single file  
-                    foreach (var tempFile in temps.OrderBy(b => b.Key))
-                    {
-                        byte[] tempFileBytes = File.ReadAllBytes(tempFile.Value);
-                        destinationStream.Write(tempFileBytes, 0, tempFileBytes.Length);
-                        File.Delete(tempFile.Value);
-                    }
-                    #endregion
-                    return result;
-                }
-            });
-        }
         internal async Task<byte[]> ReadHttpResponseStreamAsync(HttpResponseMessage httpResponse, long? length, CancellationToken ct, bool saveToFile=false, string filename=null, string folderPath=null)
         {
             return await Task.Run(async () =>
@@ -342,7 +294,6 @@ namespace Neon.Downloader
                 }
             }, ct);
         }
-
         internal byte[] FromReaderToStream(StreamReader sr, Stream destinationStream,
             ref DownloadMetric metric, ref Stopwatch stopwatch, ref long? length, CancellationToken ct)
         {
@@ -379,10 +330,12 @@ namespace Neon.Downloader
                 buffer = new byte[toDownload];
             }
             stopwatch.Stop();
+            DownloadTrace.Invoke("Download finished!");
+            DownloadTrace.Invoke("Returning results...");
             //DownloadCompleted?.Invoke(metric, destinationStream);
             //stopwatch.Reset();
-            
-            if(destinationStream is MemoryStream) {
+
+            if (destinationStream is MemoryStream) {
                 return ((MemoryStream)destinationStream).ToArray();
             }
             else {

--- a/Neon.Downloader/DownloadMetric.cs
+++ b/Neon.Downloader/DownloadMetric.cs
@@ -23,7 +23,7 @@ namespace Neon.Downloader
         {
             TimeInSeconds = timeInSeconds;
             DownloadedBytes = 0;
-            TotalBytes = totalBytes.HasValue ? totalBytes.Value : int.MaxValue;
+            TotalBytes = totalBytes ?? int.MaxValue;
             ElapsedTime = new TimeSpan();
         }
         /// <summary>
@@ -125,6 +125,10 @@ namespace Neon.Downloader
                 catch (DivideByZeroException)
                 {
                     return TimeSpan.FromSeconds(0);
+                }
+                catch (Exception)
+                {
+                    return new TimeSpan();
                 }
             }
         }

--- a/Neon.Downloader/Globals.cs
+++ b/Neon.Downloader/Globals.cs
@@ -29,6 +29,7 @@ namespace Neon.Downloader
         }
     }
 
+    public delegate void DownloadTraceEventHandler(string message);
     public delegate void DownloadEventHandler(DownloadMetric metric);
     public delegate void DownloadCompletedEventHandler(DownloadMetric metric, Stream stream);
     public delegate void DownloadErrorEventHandler(Exception ex);

--- a/Neon.Downloader/IDownloader.cs
+++ b/Neon.Downloader/IDownloader.cs
@@ -27,6 +27,10 @@ namespace Neon.Downloader
         /// operation. This event passes along an <see cref="DownloadClientException"/>
         /// </summary>
         event DownloadErrorEventHandler OnError;
+        /// <summary>
+        /// Event handler to call everytime a download related message is logged/encountered.
+        /// </summary>
+        event DownloadTraceEventHandler DownloadTrace;
 
         /// <summary>
         /// Returns all the bytes read from a HTTP resource.

--- a/Neon.Downloader/IDownloader.cs
+++ b/Neon.Downloader/IDownloader.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Neon.Downloader.Enums;
@@ -133,7 +134,8 @@ namespace Neon.Downloader
         ///     Name to use in saving the file or basically a path of where to save the file.
         /// </param>
         /// <param name="folderPath">Path to folder where to save the file.</param>
-        Task DownloadToFileAsync(string url, string filename, string folderPath);
+        Task<byte[]> DownloadToFileAsync(string url, string folder, string filename, CancellationToken ct);
+        Task<byte[]> DownloadToFileAsync(string url, Stream output, CancellationToken ct);
         /// <summary>
         /// Asynchronously downloads the contents of a remote resource/file and saves it
         /// to a Local file in the Local ApplicationData Folder using the 

--- a/Neon.Downloader/Neon.Downloader.csproj
+++ b/Neon.Downloader/Neon.Downloader.csproj
@@ -14,8 +14,9 @@
     <RepositoryUrl>https://github.com/tmacharia/download-client.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>download</PackageTags>
-    <PackageVersion>1.0.5</PackageVersion>
+    <PackageVersion>1.0.6-beta</PackageVersion>
     <NeutralLanguage>en-US</NeutralLanguage>
+    <Platforms>AnyCPU;x86;x64</Platforms>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Issues encountered working with this the previous internal download method alias `InternalDownloadAsync` thus making it obsolete.

Please migrate to using the `ProcessDownloadAsync` method which is much **efficient & resilient** to runtime errors/issues.